### PR TITLE
Specify loaders for `yaml.load`

### DIFF
--- a/pyclone/post_process/loci.py
+++ b/pyclone/post_process/loci.py
@@ -8,6 +8,11 @@ from __future__ import division
 import pandas as pd
 import yaml
 
+try:
+    from yaml import CLoader as Loader
+except ImportError:
+    from yaml import Loader
+
 from pyclone.config import load_mutation_from_dict
 
 from .clusters import cluster_pyclone_trace
@@ -109,7 +114,7 @@ def _load_sample_variant_allele_frequencies(file_name):
     data = {}
 
     with open(file_name) as fh:
-        config = yaml.load(fh)
+        config = yaml.load(fh, Loader=Loader)
 
     for mutation_dict in config['mutations']:
         mutation = load_mutation_from_dict(mutation_dict)

--- a/pyclone/run.py
+++ b/pyclone/run.py
@@ -8,9 +8,9 @@ from __future__ import division
 from collections import OrderedDict
 
 try:
-    from yaml import CDumper as Dumper
+    from yaml import CDumper as Dumper, CLoader as Loader
 except ImportError:
-    from yaml import Dumper
+    from yaml import Dumper, Loader
 
 import csv
 import os
@@ -164,7 +164,7 @@ def _write_config_file(
         }
 
     if config_extras_file is not None:
-        config.update(yaml.load(open(config_extras_file)))
+        config.update(yaml.load(open(config_extras_file), Loader=Loader))
 
     with open(config_file, 'w') as fh:
         yaml.dump(config, fh, default_flow_style=False, Dumper=Dumper)


### PR DESCRIPTION
Currently, this warning comes up when running `build_table` and other stuff:

```
pyclone/post_process/loci.py:112: YAMLLoadWarning: calling yaml.load() without Loader=... is deprecated, as the default Loader is unsafe. Please read https://msg.pyyaml.org/load for full details.
  config = yaml.load(fh)
```

This commit specifies a loader as recommended in the pyyaml wiki (https://github.com/yaml/pyyaml/wiki/PyYAML-yaml.load(input)-Deprecation#how-to-disable-the-warning)